### PR TITLE
docs: mark panic button endpoint complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ go run cmd/main.go
 - [x] Endpoint Login
 - [x] Endpoint Role
 - [x] Endpoint CRUD User
-- [ ] Endpoint kirim panic button
+- [x] Endpoint kirim panic button (lihat `routes/panic_routes.go`)
 - [ ] Integrasi Google Maps API untuk routing
 - [ ] Realtime tracking ambulans
 - [ ] Firebase Notification


### PR DESCRIPTION
## Summary
- mark panic button endpoint as complete in roadmap

## Testing
- `markdownlint README.md` *(fails: command not found even after failed npm install)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf5bf6a88332ac63a02b4e082fe6