### PR TITLE
Fix panic event variable name

### DIFF
--- a/controllers/panic_controller.go
+++ b/controllers/panic_controller.go
@@ -21,11 +21,11 @@ func SendPanic(c *gin.Context) {
 		return
 	}
 
-	pannicEvent, err := services.SendPanic(userID, input)
+	panicEvent, err := services.SendPanic(userID, input)
 	if err != nil {
 		utils.InternalServerErrorResponse(c, "Failed to send panic", err.Error())
 		return
 	}
 
-	utils.CreatedResponse(c, "Panic event created successfully", pannicEvent)
+	utils.CreatedResponse(c, "Panic event created successfully", panicEvent)
 }


### PR DESCRIPTION
## Summary
- rename pannicEvent variable to panicEvent in panic controller

## Testing
- `go fmt controllers/panic_controller.go`
- `go vet ./controllers`


------
https://chatgpt.com/codex/tasks/task_e_689bdf599a0483329283de107e829387