### PR TITLE
Add routing, tracking, notifications and analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ go run cmd/main.go
 - [x] Endpoint Login
 - [x] Endpoint Role
 - [x] Endpoint CRUD User
-- [ ] Endpoint kirim panic button
-- [ ] Integrasi Google Maps API untuk routing
-- [ ] Realtime tracking ambulans
-- [ ] Firebase Notification
-- [ ] Dashboard Analytics Endpoint
+- [x] Endpoint kirim panic button
+- [x] Integrasi Google Maps API untuk routing
+- [x] Realtime tracking ambulans
+- [x] Firebase Notification
+- [x] Dashboard Analytics Endpoint
 
 ## 👨‍💻 Kontributor
 

--- a/controllers/ambulance_controller.go
+++ b/controllers/ambulance_controller.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"smart-command-center-backend/services"
+	"smart-command-center-backend/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// UpdateAmbulanceLocation handles incoming location updates from ambulances.
+func UpdateAmbulanceLocation(c *gin.Context) {
+	var input services.AmbulanceLocationRequest
+	if err := c.ShouldBindJSON(&input); err != nil {
+		utils.BadRequestResponse(c, "Invalid input", err.Error())
+		return
+	}
+
+	location, err := services.UpdateAmbulanceLocation(input)
+	if err != nil {
+		utils.InternalServerErrorResponse(c, "Failed to update location", err.Error())
+		return
+	}
+
+	utils.SuccessResponse(c, "Ambulance location updated", location)
+}

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -1,0 +1,19 @@
+package controllers
+
+import (
+	"smart-command-center-backend/services"
+	"smart-command-center-backend/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetDashboardAnalytics returns aggregated stats for the dashboard.
+func GetDashboardAnalytics(c *gin.Context) {
+	stats, err := services.GetDashboardStats()
+	if err != nil {
+		utils.InternalServerErrorResponse(c, "Failed to fetch analytics", err.Error())
+		return
+	}
+
+	utils.SuccessResponse(c, "Dashboard analytics", stats)
+}

--- a/controllers/maps_controller.go
+++ b/controllers/maps_controller.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"smart-command-center-backend/services"
+	"smart-command-center-backend/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetRoute handles requests for calculating routes using Google Maps API.
+func GetRoute(c *gin.Context) {
+	var input services.RouteRequest
+	if err := c.ShouldBindQuery(&input); err != nil {
+		utils.BadRequestResponse(c, "Invalid query parameters", err.Error())
+		return
+	}
+
+	route, err := services.GetRoute(input)
+	if err != nil {
+		utils.InternalServerErrorResponse(c, "Failed to get route", err.Error())
+		return
+	}
+
+	utils.SuccessResponse(c, "Route fetched successfully", route)
+}

--- a/firebase/notification.go
+++ b/firebase/notification.go
@@ -1,0 +1,31 @@
+package firebase
+
+import (
+	"context"
+
+	"firebase.google.com/go/messaging"
+)
+
+// SendNotificationToTopic sends a simple notification to a topic using FCM.
+func SendNotificationToTopic(topic, title, body string) error {
+	if FirebaseApp == nil {
+		return nil
+	}
+
+	ctx := context.Background()
+	client, err := FirebaseApp.Messaging(ctx)
+	if err != nil {
+		return err
+	}
+
+	msg := &messaging.Message{
+		Topic: topic,
+		Notification: &messaging.Notification{
+			Title: title,
+			Body:  body,
+		},
+	}
+
+	_, err = client.Send(ctx, msg)
+	return err
+}

--- a/models/ambulance.go
+++ b/models/ambulance.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// AmbulanceLocation represents the latest known location of an ambulance
+// tracked in the system.
+type AmbulanceLocation struct {
+	ID          uint    `gorm:"primaryKey"`
+	AmbulanceID uint    `json:"ambulance_id" gorm:"not null"`
+	Latitude    float64 `json:"latitude" gorm:"not null"`
+	Longitude   float64 `json:"longitude" gorm:"not null"`
+	UpdatedAt   time.Time
+}

--- a/models/migrate.go
+++ b/models/migrate.go
@@ -3,7 +3,7 @@ package models
 import "gorm.io/gorm"
 
 func Migrate(db *gorm.DB) error {
-	err := db.AutoMigrate(&Role{}, &User{}, &PanicEvent{})
+	err := db.AutoMigrate(&Role{}, &User{}, &PanicEvent{}, &AmbulanceLocation{})
 	if err != nil {
 		return err
 	}

--- a/routes/ambulance_routes.go
+++ b/routes/ambulance_routes.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"smart-command-center-backend/controllers"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AmbulanceRoutes registers routes for ambulance tracking.
+func AmbulanceRoutes(rg *gin.RouterGroup) {
+	ambulance := rg.Group("/ambulance")
+	ambulance.POST("/track", controllers.UpdateAmbulanceLocation)
+}

--- a/routes/dashboard_routes.go
+++ b/routes/dashboard_routes.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"smart-command-center-backend/controllers"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DashboardRoutes registers endpoints for dashboard analytics.
+func DashboardRoutes(rg *gin.RouterGroup) {
+	dashboard := rg.Group("/dashboard")
+	dashboard.GET("/analytics", controllers.GetDashboardAnalytics)
+}

--- a/routes/maps_routes.go
+++ b/routes/maps_routes.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"smart-command-center-backend/controllers"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MapRoutes registers map related routes.
+func MapRoutes(rg *gin.RouterGroup) {
+	maps := rg.Group("/maps")
+	maps.GET("/route", controllers.GetRoute)
+}

--- a/routes/router.go
+++ b/routes/router.go
@@ -34,6 +34,9 @@ func SetupRouter() *gin.Engine {
 		UserRoutes(authorized)
 		RoleRoutes(authorized)
 		PanicRoutes(authorized)
+		MapRoutes(authorized)
+		AmbulanceRoutes(authorized)
+		DashboardRoutes(authorized)
 	}
 
 	return r

--- a/services/ambulance_service.go
+++ b/services/ambulance_service.go
@@ -1,0 +1,55 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"smart-command-center-backend/config"
+	"smart-command-center-backend/firebase"
+	"smart-command-center-backend/models"
+	"time"
+)
+
+// AmbulanceLocationRequest represents the payload for updating an ambulance location.
+type AmbulanceLocationRequest struct {
+	AmbulanceID uint    `json:"ambulance_id" binding:"required"`
+	Latitude    float64 `json:"latitude" binding:"required"`
+	Longitude   float64 `json:"longitude" binding:"required"`
+}
+
+// UpdateAmbulanceLocation inserts or updates the latest location of an ambulance.
+func UpdateAmbulanceLocation(input AmbulanceLocationRequest) (*models.AmbulanceLocation, error) {
+	if input.AmbulanceID == 0 {
+		return nil, errors.New("ambulance ID is required")
+	}
+
+	var location models.AmbulanceLocation
+	err := config.DB.Where("ambulance_id = ?", input.AmbulanceID).First(&location).Error
+	if err != nil {
+		// Create new record if not found
+		location = models.AmbulanceLocation{
+			AmbulanceID: input.AmbulanceID,
+			Latitude:    input.Latitude,
+			Longitude:   input.Longitude,
+			UpdatedAt:   time.Now(),
+		}
+		if err := config.DB.Create(&location).Error; err != nil {
+			return nil, err
+		}
+		// Notify subscribers about new ambulance location
+		_ = firebase.SendNotificationToTopic("ambulance_tracking", "Ambulance Tracking", fmt.Sprintf("Ambulance %d location updated", input.AmbulanceID))
+		return &location, nil
+	}
+
+	// Update existing record
+	location.Latitude = input.Latitude
+	location.Longitude = input.Longitude
+	location.UpdatedAt = time.Now()
+	if err := config.DB.Save(&location).Error; err != nil {
+		return nil, err
+	}
+
+	// Notify subscribers about ambulance movement
+	_ = firebase.SendNotificationToTopic("ambulance_tracking", "Ambulance Tracking", fmt.Sprintf("Ambulance %d location updated", input.AmbulanceID))
+
+	return &location, nil
+}

--- a/services/dashboard_service.go
+++ b/services/dashboard_service.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"smart-command-center-backend/config"
+	"smart-command-center-backend/models"
+)
+
+// DashboardStats represents aggregated information for the dashboard.
+type DashboardStats struct {
+	TotalUsers       int64 `json:"total_users"`
+	TotalPanicEvents int64 `json:"total_panic_events"`
+	TotalAmbulances  int64 `json:"total_ambulances"`
+}
+
+// GetDashboardStats collects simple analytics for the dashboard.
+func GetDashboardStats() (*DashboardStats, error) {
+	var users, panicEvents, ambulances int64
+
+	if err := config.DB.Model(&models.User{}).Count(&users).Error; err != nil {
+		return nil, err
+	}
+	if err := config.DB.Model(&models.PanicEvent{}).Count(&panicEvents).Error; err != nil {
+		return nil, err
+	}
+	if err := config.DB.Model(&models.AmbulanceLocation{}).Count(&ambulances).Error; err != nil {
+		return nil, err
+	}
+
+	stats := DashboardStats{
+		TotalUsers:       users,
+		TotalPanicEvents: panicEvents,
+		TotalAmbulances:  ambulances,
+	}
+	return &stats, nil
+}

--- a/services/maps_service.go
+++ b/services/maps_service.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// RouteRequest holds the coordinates for a routing request.
+type RouteRequest struct {
+	OriginLat float64 `form:"origin_lat" binding:"required"`
+	OriginLng float64 `form:"origin_lng" binding:"required"`
+	DestLat   float64 `form:"dest_lat" binding:"required"`
+	DestLng   float64 `form:"dest_lng" binding:"required"`
+}
+
+// RouteResponse is a simplified representation of Google Maps Directions API response.
+type RouteResponse struct {
+	Distance string `json:"distance"`
+	Duration string `json:"duration"`
+	Polyline string `json:"polyline"`
+}
+
+// GetRoute calls Google Maps Directions API and returns routing info.
+func GetRoute(input RouteRequest) (*RouteResponse, error) {
+	apiKey := os.Getenv("GOOGLE_MAPS_API_KEY")
+	if apiKey == "" {
+		return nil, errors.New("google maps API key not configured")
+	}
+
+	url := fmt.Sprintf("https://maps.googleapis.com/maps/api/directions/json?origin=%f,%f&destination=%f,%f&key=%s",
+		input.OriginLat, input.OriginLng, input.DestLat, input.DestLng, apiKey)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var data struct {
+		Routes []struct {
+			Legs []struct {
+				Distance struct {
+					Text string `json:"text"`
+				} `json:"distance"`
+				Duration struct {
+					Text string `json:"text"`
+				} `json:"duration"`
+			} `json:"legs"`
+			OverviewPolyline struct {
+				Points string `json:"points"`
+			} `json:"overview_polyline"`
+		} `json:"routes"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	if len(data.Routes) == 0 || len(data.Routes[0].Legs) == 0 {
+		return nil, errors.New("no routes found")
+	}
+
+	route := data.Routes[0]
+	leg := route.Legs[0]
+	result := RouteResponse{
+		Distance: leg.Distance.Text,
+		Duration: leg.Duration.Text,
+		Polyline: route.OverviewPolyline.Points,
+	}
+	return &result, nil
+}

--- a/services/panic_service.go
+++ b/services/panic_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	"smart-command-center-backend/config"
+	"smart-command-center-backend/firebase"
 	"smart-command-center-backend/models"
 	"time"
 )
@@ -29,6 +30,9 @@ func SendPanic(userID uint, input PanicRequest) (*models.PanicEvent, error) {
 	if err := config.DB.Create(&panicData).Error; err != nil {
 		return nil, errors.New("failed to create panic event")
 	}
+
+	// Send notification to responders
+	_ = firebase.SendNotificationToTopic("panic_alerts", "Panic Alert", "A new panic event has been reported")
 
 	return &panicData, nil
 }


### PR DESCRIPTION
## Summary
- send FCM alerts when panic button is triggered
- integrate Google Maps Directions API for routing
- add real-time ambulance tracking with push updates
- expose dashboard analytics metrics

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(hangs: network access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc73b4e48332bdc2d3c5f2300f70